### PR TITLE
Update CD workflow to build with pnpm and upload dist assets

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,13 +31,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build
+        run: pnpm build
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          # Upload built assets
+          path: './dist'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Updated the GitHub workflow `.github/workflows/cd.yml` to include steps for building the project using `pnpm` before deployment. The workflow now installs dependencies, runs the build command, and uploads the `dist` directory instead of the entire repository.

---
*PR created automatically by Jules for task [7470505463279684149](https://jules.google.com/task/7470505463279684149) started by @MrOrz*